### PR TITLE
Ignore hidden directories

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,6 +22,7 @@ func rootCmdExec(cmd *cobra.Command, args []string) error {
 	fUnusedOnly, _ := cmd.Flags().GetBool("unused-only")
 	fVariables, _ := cmd.Flags().GetBool("variables")
 	fLocals, _ := cmd.Flags().GetBool("locals")
+	fIgnoreHiddenDirs, _ := cmd.Flags().GetBool("ignore-hidden-dirs")
 
 	dType := terraform.All
 	if fVariables && !fLocals {
@@ -30,7 +31,7 @@ func rootCmdExec(cmd *cobra.Command, args []string) error {
 		dType = terraform.Locals
 	}
 
-	modules, err := terraform.ListTfModules(dir)
+	modules, err := terraform.ListTfModules(dir, fIgnoreHiddenDirs)
 	if err != nil {
 		return err
 	}
@@ -46,8 +47,7 @@ func rootCmdExec(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	fmt.Printf("\n%d modules processed", len(modules))
-
+	fmt.Printf("\n%d modules processed\n", len(modules))
 	return nil
 }
 
@@ -59,4 +59,5 @@ func init() {
 	rootCmd.Flags().Bool("unused-only", false, "Display only unused values")
 	rootCmd.Flags().Bool("variables", false, "Display only variables")
 	rootCmd.Flags().Bool("locals", false, "Display only locals")
+	rootCmd.Flags().Bool("ignore-hidden-dirs", false, "Ignore hidden directories")
 }

--- a/terraform/main.go
+++ b/terraform/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 )
 
 type ModuleUsage struct {
@@ -42,12 +43,34 @@ func NewModuleUsage(path string) (*ModuleUsage, error) {
 	return m, err
 }
 
-func ListTfModules(path string) (map[string]bool, error) {
+func isHidden(path string) bool {
+	parts := strings.Split(path, string(filepath.Separator))
+	for _, part := range parts {
+		if part == "." || part == ".." {
+			continue
+		}
+		if strings.HasPrefix(part, ".") {
+			return true
+		}
+	}
+	return false
+}
+
+func ListTfModules(path string, ignoreHiddenDirs bool) (map[string]bool, error) {
 	var directories = make(map[string]bool)
 
 	err := filepath.WalkDir(path, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
+		}
+
+		if ignoreHiddenDirs {
+			if isHidden(path) {
+				if d.IsDir() {
+					log.Debugf("Skipping: %v", d.Name())
+					return fs.SkipDir
+				}
+			}
 		}
 
 		if filepath.Ext(path) == ".tf" {
@@ -166,15 +189,15 @@ func (m ModuleUsage) Display(dType DisplayType, unusedOnly bool) error {
 	}
 
 	if !unusedOnly || (unusedOnly && len(locals)+len(variables) > 0) {
-		fmt.Printf("\n \U0001F680 Module: %s\n", m.Path)
+		fmt.Printf("\n\U0001F680 Module: %s\n", m.Path)
 	}
 
 	if dType == All || dType == Variables {
 		if !unusedOnly || (unusedOnly && len(variables) > 0) {
-			fmt.Printf(" \U0001F449 %d variables found\n", len(variables))
+			fmt.Printf("\U0001F449 %d variables found\n", len(variables))
 		}
 		for name, count := range variables {
-			fmt.Printf("%s : %d\n", name, count)
+			fmt.Printf(" %s : %d\n", name, count)
 		}
 	}
 
@@ -183,7 +206,7 @@ func (m ModuleUsage) Display(dType DisplayType, unusedOnly bool) error {
 			fmt.Printf("\U0001F449 %d locals found\n", len(locals))
 		}
 		for name, count := range locals {
-			fmt.Printf("%s : %d\n", name, count)
+			fmt.Printf(" %s : %d\n", name, count)
 		}
 
 	}

--- a/terraform/main_test.go
+++ b/terraform/main_test.go
@@ -6,16 +6,17 @@ import (
 )
 
 func TestListTfModules(t *testing.T) {
-	t.Run("must found 3 modules", func(t *testing.T) {
+	t.Run("must found 4 modules", func(t *testing.T) {
 		path := "./testdata"
 
-		result, err := ListTfModules(path)
+		result, err := ListTfModules(path, false)
 		assert.Equal(t, err, nil)
-		assert.Equal(t, len(result), 3)
+		assert.Equal(t, len(result), 4)
 
 		assert.Contains(t, result, "testdata")
 		assert.Contains(t, result, "testdata/tf")
 		assert.Contains(t, result, "testdata/tf/1")
+		assert.Contains(t, result, "testdata/.hidden-tf-files")
 	})
 }
 
@@ -36,5 +37,19 @@ func TestNewModuleUsage(t *testing.T) {
 		assert.Equal(t, 1, moduleUsage.Locals["tags"])
 		assert.Equal(t, 0, moduleUsage.Locals["dummy"])
 		assert.Equal(t, 0, moduleUsage.Locals["dummy2"])
+	})
+}
+
+func TestListTfIgnoreHiddenDirs(t *testing.T) {
+	t.Run("must found 3 modules", func(t *testing.T) {
+		path := "./testdata"
+
+		result, err := ListTfModules(path, true)
+		assert.Equal(t, err, nil)
+		assert.Equal(t, len(result), 3)
+
+		assert.Contains(t, result, "testdata")
+		assert.Contains(t, result, "testdata/tf")
+		assert.Contains(t, result, "testdata/tf/1")
 	})
 }


### PR DESCRIPTION
Adding capability to be able to ignore hidden directories

**Reason**

- I have encountered where the tool will recursively check `.terraform/` directory when I'm in a project and using external modules, I just want to scan the `.tf` files I may be writing